### PR TITLE
Add ONNX and multiprocessing functionalities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .DS_Store
 model/
 log/
+PPO*/
+run/
+wandb/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ log/
 PPO*/
 run/
 wandb/
+*.onnx

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ PPO*/
 run/
 wandb/
 *.onnx
+diffusers_old/
+**/launch.json 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/__pycache__/
 .DS_Store
 model/
+log/

--- a/envs/env.py
+++ b/envs/env.py
@@ -215,7 +215,7 @@ class DiffusionEnv(gym.Env):
         # print('info:', info)
         observation = {
             "image": self.current_image.squeeze(0),  
-            "value": np.array([t.item()]) # TODO: check shape
+            "value": np.array([t.item()]) # make sure it has the shape of (1,)
         }
         #     prof.step()
         # print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=20))

--- a/envs/eval_env.py
+++ b/envs/eval_env.py
@@ -70,7 +70,7 @@ class EvalDiffusionEnv(gym.Env):
         self.time_step_sequence = []
         self.current_image = torch.randn((1, 3, self.sample_size, self.sample_size), device="cuda", generator=self.generator)
         observation = {
-            "image": self.current_image.cpu().numpy(),  
+            "image": self.current_image.squeeze(0).cpu().numpy(),  
             "value": np.array([999])
         }
         return observation, {}
@@ -119,8 +119,8 @@ class EvalDiffusionEnv(gym.Env):
         }
         # print('info:', info)
         observation = {
-            "image": self.current_image,  
-            "value": t
+            "image": self.current_image.squeeze(0),  
+            "value": np.array([t.item()]) # make sure it has the shape of (1,)
         }
         # Save the image if done
         if done and self.img_save_path is not None:

--- a/eval.py
+++ b/eval.py
@@ -56,10 +56,11 @@ if __name__ == "__main__":
         features_extractor_class=CustomCNN,
         features_extractor_kwargs=dict(features_dim=32),
     )
+    # Restore config
     my_config = {
         "run_id": args.run_id,
 
-        "algorithm": MD_SAC,
+        "algorithm": PPO,
         "policy_network": "MultiInputPolicy",
         "save_path": args.save_path,
 
@@ -70,12 +71,12 @@ if __name__ == "__main__":
         "max_steps": args.target_steps,
 
         "num_eval_envs": 1,
-        "eval_num": 50000,
+        "eval_num": 50000, # 50000
         "img_save_path": args.img_save_path,
         "action_range": args.action_range
     }
     ### Load model with SB3
-    model = SAC.load(my_config['save_path'])
+    model = PPO.load(my_config['save_path'])
     env = DummyVecEnv([make_env(my_config) for _ in range(my_config['num_eval_envs'])])
     
     evaluation(env, model, my_config['eval_num'])

--- a/onnx_funcs/onnx_export.py
+++ b/onnx_funcs/onnx_export.py
@@ -27,15 +27,15 @@ pipeline = DiffusionPipeline.from_pretrained(model_id)
 
 # Define a dummy input matching the model's expected input size
 dummy_input = torch.randn(1, pipeline.unet.in_channels, pipeline.unet.sample_size, pipeline.unet.sample_size)
-dummy_timestep = torch.tensor([0], dtype=torch.long)
+dummy_timestep = torch.tensor(0, dtype=torch.long)
 
 # Export the UNet model to ONNX
 torch.onnx.export(
     pipeline.unet,                      # The model to export
-    (dummy_input, dummy_timestep),                        # The model's input
-    f"{output}.onnx",    # The output file
+    (dummy_input, dummy_timestep),      # The model's input
+    f"{output}.onnx",                   # The output file
     opset_version=18,                   # ONNX opset version
-    input_names=["input"],              # Input tensor name
+    input_names=["input", "timesteps"],              # Input tensor name
     output_names=["output"],            # Output tensor name
     dynamic_axes={"input": {0: "batch_size"}, "output": {0: "batch_size"}},  # Enable dynamic batching
 )

--- a/onnx_funcs/onnx_export.py
+++ b/onnx_funcs/onnx_export.py
@@ -1,0 +1,41 @@
+from diffusers import DDPMPipeline, DDIMPipeline, DiffusionPipeline
+
+import torch
+import argparse
+import onnxruntime
+import numpy as np
+
+parser = argparse.ArgumentParser(description="ONNX Export Script")
+parser.add_argument("--model", type=str, required=True, help="Model ID to use for the pipeline")
+parser.add_argument("--type", type=str, required=True, help="Type of model to use")
+parser.add_argument("--output", "-o", type=str, required=True, help="Output file name for the ONNX model")
+
+args = parser.parse_args()
+model_id = args.model
+model_type = args.type
+output = args.output
+
+# if model_type == "DDPM":
+#     pipeline = DDPMPipeline.from_pretrained(model_id)
+# elif model_type == "DDIM":
+#     pipeline = DDIMPipeline.from_pretrained(model_id)
+# else:
+#     print("Unrecognized model type!")
+#     exit()
+
+pipeline = DiffusionPipeline.from_pretrained(model_id)
+
+# Define a dummy input matching the model's expected input size
+dummy_input = torch.randn(1, pipeline.unet.in_channels, pipeline.unet.sample_size, pipeline.unet.sample_size)
+dummy_timestep = torch.tensor([0], dtype=torch.long)
+
+# Export the UNet model to ONNX
+torch.onnx.export(
+    pipeline.unet,                      # The model to export
+    (dummy_input, dummy_timestep),                        # The model's input
+    f"{output}.onnx",    # The output file
+    opset_version=18,                   # ONNX opset version
+    input_names=["input"],              # Input tensor name
+    output_names=["output"],            # Output tensor name
+    dynamic_axes={"input": {0: "batch_size"}, "output": {0: "batch_size"}},  # Enable dynamic batching
+)

--- a/onnx_funcs/onnx_test.py
+++ b/onnx_funcs/onnx_test.py
@@ -35,7 +35,10 @@ session = onnxruntime.InferenceSession(onnx_model_path, providers=['CUDAExecutio
 
 # Set a fixed seed for reproducibility
 torch.manual_seed(42)
+torch.cuda.manual_seed(42)
 np.random.seed(42)
+torch.backends.cudnn.deterministic = True
+torch.backends.cudnn.benchmark = False
 
 # Define the input shape based on the model's expected dimensions
 batch_size = 1
@@ -65,10 +68,7 @@ dummy_timesteps_onnx = dummy_timesteps_torch.cpu().numpy()
 
 # Run inference with the PyTorch model
 with torch.no_grad():
-    torch_output = pipeline.unet(
-        sample=dummy_input_torch,
-        timesteps=dummy_timesteps_torch,
-    ).cpu().numpy()
+    torch_output = pipeline.unet(dummy_input_torch,dummy_timesteps_torch).sample.cpu().numpy()
 
 # Run inference with the ONNX model
 # Get the input and output names for the ONNX model

--- a/onnx_funcs/onnx_test.py
+++ b/onnx_funcs/onnx_test.py
@@ -1,0 +1,98 @@
+from diffusers import DDPMPipeline, DDIMPipeline, DiffusionPipeline
+
+import onnxruntime
+import numpy as np
+import torch
+import argparse
+
+parser = argparse.ArgumentParser(description="ONNX test Script")
+parser.add_argument("--model", type=str, required=True, help="Model ID to use for the pipeline")
+parser.add_argument("--type", type=str, required=False, help="Type of model to use")
+parser.add_argument("--dir", "-d", type=str, required=True, help="File directory for the ONNX model")
+
+args = parser.parse_args()
+model_id = args.model
+model_type = args.type
+onnx_model_path = args.dir
+
+# Load the pipeline based on the model type
+# if model_type == "DDPM":
+#     pipeline = DDPMPipeline.from_pretrained(model_id)
+# elif model_type == "DDIM":
+#     pipeline = DDIMPipeline.from_pretrained(model_id)
+# else:
+#     pipeline = DiffusionPipeline.from_pretrained(model_id)
+
+pipeline = DiffusionPipeline.from_pretrained(model_id)
+
+# Move the model to the desired device
+device = "cuda" if torch.cuda.is_available() else "cpu"
+pipeline.to(device)
+pipeline.unet.eval()
+
+# Load the ONNX model
+session = onnxruntime.InferenceSession(onnx_model_path, providers=['CUDAExecutionProvider'])
+
+# Set a fixed seed for reproducibility
+torch.manual_seed(42)
+np.random.seed(42)
+
+# Define the input shape based on the model's expected dimensions
+batch_size = 1
+in_channels = pipeline.unet.in_channels
+sample_size = pipeline.unet.sample_size
+
+# Create a dummy input tensor for PyTorch
+dummy_input_torch = torch.randn(
+    batch_size,
+    in_channels,
+    sample_size,
+    sample_size,
+    dtype=torch.float32,
+    device=device,
+)
+
+# Create a dummy timesteps tensor for PyTorch
+dummy_timesteps_torch = torch.tensor(
+    [0],  # You can choose any valid timestep value
+    dtype=torch.long,
+    device=device,
+)
+
+# Convert the PyTorch tensors to NumPy arrays for ONNX Runtime
+dummy_input_onnx = dummy_input_torch.cpu().numpy()
+dummy_timesteps_onnx = dummy_timesteps_torch.cpu().numpy()
+
+# Run inference with the PyTorch model
+with torch.no_grad():
+    torch_output = pipeline.unet(
+        sample=dummy_input_torch,
+        timesteps=dummy_timesteps_torch,
+    ).cpu().numpy()
+
+# Run inference with the ONNX model
+# Get the input and output names for the ONNX model
+onnx_input_names = [input.name for input in session.get_inputs()]
+onnx_output_name = session.get_outputs()[0].name
+
+# Prepare the inputs for the ONNX model
+onnx_inputs = {
+    onnx_input_names[0]: dummy_input_onnx,
+    onnx_input_names[1]: dummy_timesteps_onnx,
+}
+
+# Run inference with the ONNX model
+onnx_outputs = session.run([onnx_output_name], onnx_inputs)
+onnx_output = onnx_outputs[0]
+
+# Calculate the absolute difference
+difference = np.abs(torch_output - onnx_output)
+
+# Calculate metrics
+max_diff = difference.max()
+mean_diff = difference.mean()
+std_diff = difference.std()
+
+print(f"Max difference: {max_diff}")
+print(f"Mean difference: {mean_diff}")
+print(f"Standard deviation of difference: {std_diff}")

--- a/onnx_wrapper.py
+++ b/onnx_wrapper.py
@@ -1,0 +1,22 @@
+import torch
+
+class ONNXUNetWrapper:
+    def __init__(self, ort_session):
+        self.ort_session = ort_session
+        self.onnx_input_names = [input.name for input in ort_session.get_inputs()]
+        self.onnx_output_name = ort_session.get_outputs()[0].name
+
+    def __call__(self, input_tensor, timestep_tensor):
+        sample = input_tensor.detach().cpu().numpy()
+        timestep = timestep_tensor.detach().cpu().numpy()
+        
+        ort_inputs = {
+            self.onnx_input_names[0]: sample,
+            self.onnx_input_names[1]: timestep
+        }
+        ort_outs = self.ort_session.run([self.onnx_output_name], ort_inputs)
+        out_sample = torch.from_numpy(ort_outs[0]).to("cuda")
+        class OutputWrapper:
+            def __init__(self, sample):
+                self.sample = sample
+        return OutputWrapper(out_sample)

--- a/perfRecord.py
+++ b/perfRecord.py
@@ -1,0 +1,116 @@
+import time
+
+class PerformanceRecord():
+    def __init__(self) -> None:
+        self.stepsPerEpoch = []
+        self.stepCount = 0
+        self.stepStart = 0
+        self.stepTime = 0
+        self.ddimStart = 0
+        self.ddimStepTime = 0
+        self.rewardStart = 0
+        self.rewardTime = 0
+        self.resetStart = 0
+        self.resetTime = 0
+        self.resetCount = 0
+        self.stepTimeRecorded = False
+        self.ddimTimeRecorded = False
+        self.rewardTimeRecorded = False
+        self.resetTimeRecorded = False
+    
+    def stepTick(self):
+        self.stepStart = time.time_ns()
+    
+    def stepTock(self):
+        stepEnd = time.time_ns()
+        if self.stepTime == 0:
+            self.stepTime = stepEnd - self.stepStart
+        else:
+            self.stepTime = (self.stepTime + stepEnd - self.stepStart) / 2
+        self.stepTimeRecorded = True
+
+    def ddimTick(self):
+        self.ddimStart = time.time_ns()
+    
+    def ddimTock(self):
+        ddimEnd = time.time_ns()
+        if self.ddimStepTime == 0:
+            self.ddimStepTime = ddimEnd - self.ddimStart
+        else:
+            self.ddimStepTime = (self.ddimStepTime + ddimEnd - self.ddimStart) / 2
+        self.ddimTimeRecorded = True
+
+    def rewardTick(self):
+        self.rewardStart = time.time_ns()
+    
+    def rewardTock(self):
+        rewardEnd = time.time_ns()
+        if self.rewardTime == 0:
+            self.rewardTime = rewardEnd - self.rewardStart
+        else:
+            self.rewardTime = (self.rewardTime + rewardEnd - self.rewardStart) / 2
+        self.rewardTimeRecorded = True
+
+    def resetTick(self):
+        self.resetStart = time.time_ns()
+    
+    def resetTock(self):
+        resetEnd = time.time_ns()
+        if self.resetTime == 0:
+            self.resetTime = resetEnd - self.resetStart
+        else:
+            self.resetTime = (self.resetTime + resetEnd - self.resetStart) / 2
+        self.resetTimeRecorded = True
+        self.resetCount += 1
+
+    def isStepTimeRecorded(self) -> bool:
+        return self.stepTimeRecorded
+    
+    def isDDIMTimeRecorded(self) -> bool:
+        return self.ddimTimeRecorded
+
+    def isResetTimeRecorded(self) -> bool:
+        return self.resetTimeRecorded
+    
+    def isRewardTimeRecorded(self) -> bool:
+        return self.rewardTimeRecorded
+        
+    def epochTick(self):
+        self.stepCount += 1
+    
+    def epochTock(self):
+        self.stepsPerEpoch.append(self.stepCount)
+        self.stepCount = 0
+
+    def printResults(self):
+        print("\nPerformance results")
+        if self.stepsPerEpoch:
+            average_steps = sum(self.stepsPerEpoch) / len(self.stepsPerEpoch)
+            print(f"Average steps per epoch: {average_steps}")
+        else:
+            print("No epochs recorded.")
+        if self.stepTimeRecorded:
+            stepTime_ms = self.stepTime / 1000
+            print(f"Average time used per step: {stepTime_ms} microseconds")
+        else:
+            print("Step time not recorded.")
+        if self.ddimTimeRecorded:
+            ddimTime_ms = self.ddimStepTime / 1000
+            print(f"Average time used per DDIM step: {ddimTime_ms} microseconds")
+        else:
+            print("DDIM time not recorded.")
+        if self.rewardTimeRecorded:
+            rewardTime_ms = self.rewardTime / 1000
+            print(f"Average time used per reward: {rewardTime_ms} microseconds")
+        else:
+            print("Reward time not recorded.")
+        if self.resetTimeRecorded:
+            resetTime_ms = self.resetTime / 1000
+            print(f"Average time used per reset: {resetTime_ms} microseconds")
+            print(f"Reset was called {self.resetCount} times.")
+        else:
+            print("Reset time not recorded.")
+
+
+global recorder
+recorder = PerformanceRecord()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ wandb==0.18.3
 tensorboard==2.18.0
 scikit-image
 diffusers
+onnxruntime-gpu==1.18.0

--- a/train.py
+++ b/train.py
@@ -165,15 +165,15 @@ def main():
         features_extractor_class=CustomCNN,
         features_extractor_kwargs=dict(features_dim=32),
     )
-    # TODO: restore config
+    # TODO: extract config
     my_config = {
         "run_id": "PPO_test_multi",
 
         "algorithm": PPO,
         "policy_network": "MultiInputPolicy",
-        "save_path": "model/PPO_test_onnx",
+        "save_path": "model/PPO_test_multi_cifar10",
 
-        "epoch_num": 1, # default is 500
+        "epoch_num": 500, # default is 500
         "timesteps_per_epoch": 100,
         "eval_episode_num": 10,
         "learning_rate": 1e-4,


### PR DESCRIPTION
# Description
As mentioned in title, while multiprocessing of evaluation still to be handled.
ONNX is covered by a new parameter "mode", if not specified, it should be using diffusers by default.
# TODO
1. Extract the training/evaluating parameters to an external file, so the status of train.py/eval.py would not be affected by any of their changes.
2. Check why ONNX is not working with scheduler (pred_epsilon=None, cannot proceed)
